### PR TITLE
Disable SSE when compile vs2013 or superior

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -274,6 +274,9 @@ if(NOT CROSSCOMPILE_MULTILIB AND CPU_IS_x86)
     #MSVC 64 bit does not have MMX, overrule it
     if (${SIZEOF_CPU} EQUAL 64 AND MSVC)
         OVERRULE_ARCH(mmx "No MMX for Win64")
+	if (MSVC_VERSION GREATER 1700)
+            OVERRULE_ARCH(sse "No SSE for Win64 Visual Studio 2013")
+        endif()
     endif()
 
 endif()


### PR DESCRIPTION
So far it has been the way I found to be able to compile using Visual Studio, without disabling SSE to 64 bit, it apprehends a linkage error.

I still do not know the general structure of the project, so I did it in my view was palliative, just to allow me to use in my project.